### PR TITLE
Fix typos and update save directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,17 +69,20 @@ early_stopping_patience: 3
 early_stopping_min_delta: 0.01
 logger: wandb
 checkpoint_callback: False
-save_dir: /outputs
+save_dir: ./outputs
 ```
 
 ### classifier
 
 ```bash
 rye shell
-python main.py dataset=yourdataset, models=modelsname,trainer=yourtrainer
+python main.py dataset=yourdataset models=modelsname trainer=yourtrainer
 ```
 
 #### multi-run
 ```bash
-python main.py -m dataset=yourdataset1,yourdataset2, models=modelsname1,modelsname2,trainer=yourtrainer
+python main.py -m \
+dataset=yourdataset1,yourdataset2 \
+models=modelsname1,modelsname2 \
+trainer=yourtrainer
 ```

--- a/config.py
+++ b/config.py
@@ -19,14 +19,14 @@ class TrainerConfig:
     lr: float = 0.01
     optim_name: str = "SGD"
     momentum: float = 0.9
-    num_fold: int = 5
+    num_folds: int = 5
     early_stopping_patience: int = 3
     early_stopping_min_delta: float = 0.01
     early_stopping_mode: str = "min"
     early_stopping_monitor: str = "loss/val_loss"
     logger: str = "wandb"
     checkpoint_callback: bool = True
-    save_dir: str = "models"
+    save_dir: str = "./outputs"
 
 
 @dataclass

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,4 +6,4 @@ defaults:
 
 hydra:
   run:
-    dir: /saves/outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    dir: ./outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}

--- a/config/trainer/default.yaml
+++ b/config/trainer/default.yaml
@@ -14,4 +14,4 @@ early_stopping_patience: 3
 early_stopping_min_delta: 0.01
 logger: wandb
 checkpoint_callback: False
-save_dir: /outputs
+save_dir: ./outputs

--- a/main.py
+++ b/main.py
@@ -86,7 +86,7 @@ def setup_dataloader(dataset, train_idx, val_idx, batch_size, generator, num_wor
 def main(cfg: Config) -> None:
     pl.seed_everything(cfg.trainer.seed)
     kf = KFold(
-        n_splits=cfg.trainer.num_fold,
+        n_splits=cfg.trainer.num_folds,
         shuffle=True,
         random_state=cfg.trainer.seed,
     )


### PR DESCRIPTION
This pull request fixes a typo in the `num_folds` variable name and updates the save directory from `/outputs` to `./outputs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - 設定ファイルの保存パスを`/outputs`から`./outputs`に変更しました。
  - `classifier`セクションのコマンドライン引数を読みやすくするために、カンマを削除しスペースを追加しました。
  - `multi-run`セクションのコマンドライン引数に改行とバックスラッシュを追加して、可読性と保守性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->